### PR TITLE
Fix CORS config for usage in Codespaces

### DIFF
--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -348,8 +348,8 @@ jhipster:
 <%_ if (!applicationTypeMicroservice) { _%>
   # CORS is only enabled by default with the "dev" profile
   cors:
-    # Allow Ionic for JHipster by default (* no longer allowed in Spring Boot 2.4+)
-    allowed-origins: "http://localhost:8100,https://localhost:8100,http://localhost:9000,https://localhost:9000<%_ if (!skipClient) { _%>,http://localhost:<%= devServerPort %>,https://localhost:<%= devServerPort %><%_ if (applicationTypeGateway && microfrontend) { for ({applicationIndex, devServerPort: microserviceDevServerPort = devServerPort + applicationIndex} of Object.values(jhipsterConfig.applications || {})) { _%>,http://localhost:<%= microserviceDevServerPort %>,https://localhost:<%= microserviceDevServerPort %><%_ } } _%><%_ } _%>"
+    # Enable CORS when running locally or in GitHub Codespaces
+    allowed-origin-patterns: 'https?://*.githubpreview.dev:*, https?://localhost:*'
     allowed-methods: "*"
     allowed-headers: "*"
   <%_ if (authenticationTypeSession) { _%>


### PR DESCRIPTION
Replaced `allowed-origins` setting with `allowed-origin-patterns` to allow simplified CORS support for both local and GitHub Codespaces usages

Co-authored-by: Sandra Ahlgrimm <Sandra.Kriemann@gmail.com>
